### PR TITLE
[^] Fix psr/http-message version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "slim/slim": "^4.10",
         "rakit/validation": "^1.4"
     },
+    "conflict": {
+        "psr/http-message": ">=2"
+    },
     "autoload": {
         "psr-4": { "Comet\\": "src/" }
     }


### PR DESCRIPTION
The new version of psr/http-message causes an error:

`Declaration of Comet\Request::getServerParams() must be compatible with Psr\Http\Message\ServerRequestInterface::getServerParams(): array in /app/vendor/gotzmann/comet/src/Request.php on line 266`