### PR TITLE
[^] Fix issues caused by the second version  of psr/http-message

### DIFF
--- a/src/Psr/MessageTrait.php
+++ b/src/Psr/MessageTrait.php
@@ -3,6 +3,7 @@
 namespace Comet\Psr;
 
 use Comet\Utils;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -12,30 +13,30 @@ use Psr\Http\Message\StreamInterface;
 trait MessageTrait
 {
     /** @var array Map of all registered headers, as original name => array of values */
-    private $headers = [];
+    private array $headers = [];
 
     /** @var array Map of lowercase header name => original name at registration */
-    private $headerNames  = [];
+    private array $headerNames  = [];
 
     /** @var string */
-    private $protocol = '1.1';
+    private string $protocol = '1.1';
 
     /** @var StreamInterface|null */
-    private $stream;
+    private ?StreamInterface $stream;
 
     /**
      * @return string
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol;
     }
 
     /**
      * @param $version
-     * @return $this
+     * @return MessageInterface
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version): MessageInterface
     {
         $this->protocol = $version;
         return $this;
@@ -44,7 +45,7 @@ trait MessageTrait
     /**
      * @return array
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -53,16 +54,16 @@ trait MessageTrait
      * @param $header
      * @return bool
      */
-    public function hasHeader($header)
+    public function hasHeader($header): bool
     {
         return isset($this->headerNames[strtolower($header)]);
     }
 
     /**
      * @param $header
-     * @return array|mixed
+     * @return string[]
      */
-    public function getHeader($header)
+    public function getHeader($header): array
     {
         $header = strtolower($header);
 
@@ -79,7 +80,7 @@ trait MessageTrait
      * @param $header
      * @return string
      */
-    public function getHeaderLine($header)
+    public function getHeaderLine($header): string
     {
         return implode(', ', $this->getHeader($header));
     }
@@ -87,9 +88,9 @@ trait MessageTrait
     /**
      * @param $header
      * @param $value
-     * @return $this
+     * @return MessageInterface
      */
-    public function withHeader($header, $value)
+    public function withHeader($header, $value): MessageInterface
     {
         // Skip assertHeader
         $value = $this->normalizeHeaderValue($value);
@@ -107,9 +108,9 @@ trait MessageTrait
 
     /**
      * @param array $headers
-     * @return $this
+     * @return MessageInterface
      */
-    public function withHeaders(array $headers)
+    public function withHeaders(array $headers): MessageInterface
     {
         foreach ($headers as $header => $value) {
             if (!is_array($value)) {
@@ -132,9 +133,9 @@ trait MessageTrait
     /**
      * @param $header
      * @param $value
-     * @return $this
+     * @return MessageInterface
      */
-    public function withAddedHeader($header, $value)
+    public function withAddedHeader($header, $value): MessageInterface
     {
         // Skip assertHeader and normalizeHeaderValue
         $normalized = strtolower($header);
@@ -151,9 +152,9 @@ trait MessageTrait
 
     /**
      * @param $header
-     * @return $this
+     * @return MessageInterface
      */
-    public function withoutHeader($header)
+    public function withoutHeader($header): MessageInterface
     {
         $normalized = strtolower($header);
 
@@ -171,7 +172,7 @@ trait MessageTrait
     /**
      * @return StreamInterface|null
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         if (!$this->stream) {
             $this->stream = Utils::streamFor('');
@@ -182,9 +183,9 @@ trait MessageTrait
 
     /**
      * @param StreamInterface $body
-     * @return $this
+     * @return MessageInterface
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         if ($body === $this->stream) {
             return $this;
@@ -196,9 +197,9 @@ trait MessageTrait
 
     /**
      * @param array $headers
-     * @return $this
+     * @return MessageInterface
      */
-    private function setHeaders(array $headers)
+    private function setHeaders(array $headers): MessageInterface
     {
         $this->headers = [];
         $this->headerNames = [];
@@ -221,7 +222,7 @@ trait MessageTrait
     }
 
     /**
-     * DEPRECATED
+     * @deprecated
      * @param $value
      * @return string[]
      */
@@ -239,7 +240,7 @@ trait MessageTrait
     }
 
     /**
-     * DEPRECATED
+     * @deprecated
      *
      * Trims whitespace from the header values.
      *
@@ -269,7 +270,7 @@ trait MessageTrait
     }
 
     /**
-     * DEPRECATED
+     * @deprecated
      * @param $header
      */
     private function assertHeader($header)

--- a/src/Request.php
+++ b/src/Request.php
@@ -189,7 +189,7 @@ class Request implements ServerRequestInterface
     /**
      * We should not allow creating requests from GLOBALS with Workerman-based framework
      *
-     * @throws InvalidArgumentException 
+     * @throws InvalidArgumentException
      */
     public static function fromGlobals()
     {
@@ -263,7 +263,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getServerParams()
+    public function getServerParams(): array
     {
         return $this->serverParams;
     }
@@ -271,7 +271,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getUploadedFiles()
+    public function getUploadedFiles(): array
     {
         return $this->uploadedFiles;
     }
@@ -279,7 +279,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles): ServerRequestInterface
     {
         $this->uploadedFiles = $uploadedFiles;
 
@@ -289,7 +289,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getCookieParams()
+    public function getCookieParams(): array
     {
         return $this->cookieParams;
     }
@@ -297,7 +297,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies): ServerRequestInterface
     {
         $this->cookieParams = $cookies;
 
@@ -307,7 +307,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getQueryParams()
+    public function getQueryParams(): array
     {
         return $this->queryParams;
     }
@@ -315,7 +315,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query): ServerRequestInterface
     {
         $this->queryParams = $query;
 
@@ -333,7 +333,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withParsedBody($data)
+    public function withParsedBody($data): ServerRequestInterface
     {
         $this->parsedBody = $data;
 
@@ -343,7 +343,7 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -367,15 +367,7 @@ class Request implements ServerRequestInterface
      * @param $value
      * @return Request
      */
-    public function setAttribute($attribute, $value)
-    {
-        $this->attributes[$attribute] = $value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function withAttribute($attribute, $value)
+    public function setAttribute($attribute, $value): ServerRequestInterface
     {
         $this->attributes[$attribute] = $value;
 
@@ -385,7 +377,17 @@ class Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withoutAttribute($attribute)
+    public function withAttribute($attribute, $value): ServerRequestInterface
+    {
+        $this->attributes[$attribute] = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withoutAttribute($attribute): ServerRequestInterface
     {
         if (false === array_key_exists($attribute, $this->attributes)) {
             return $this;

--- a/src/Response.php
+++ b/src/Response.php
@@ -125,7 +125,7 @@ class Response implements ResponseInterface
      * @param null $headers Optional HTTP Headers
      * @return Response Comet PSR-7 HTTP Response
      */
-    public function with($body, $status = null)
+    public function with($body, $status = null): self
     {
         if ($status) {
             $this->statusCode = (int) $status;
@@ -153,7 +153,7 @@ class Response implements ResponseInterface
      * @param $headers
      * @return Response
      */
-    public function withHeaders($headers)
+    public function withHeaders($headers): self
     {
         $this->setHeaders($headers);
         return $this;
@@ -164,7 +164,7 @@ class Response implements ResponseInterface
      * @param null $status
      * @return $this
      */
-    public function withText($body, $status = null)
+    public function withText($body, $status = null): self
     {
         if (isset($status)) {
             $this->statusCode = (int) $status;
@@ -183,7 +183,7 @@ class Response implements ResponseInterface
     /**
      * @return int
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->statusCode;
     }
@@ -191,7 +191,7 @@ class Response implements ResponseInterface
     /**
      * @return mixed|string|null
      */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->reasonPhrase;
     }
@@ -201,7 +201,7 @@ class Response implements ResponseInterface
      * @param string $reasonPhrase
      * @return Response
      */
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus($code, $reasonPhrase = ''): ResponseInterface
     {
         $this->statusCode = (int) $code;
         if ($reasonPhrase == '' && isset(self::$phrases[$this->statusCode])) {
@@ -213,7 +213,7 @@ class Response implements ResponseInterface
     }
 
     /**
-     * DEPRECATED
+     * @deprecated
      * @param $statusCode
      */
     private function assertStatusCodeIsInteger($statusCode)
@@ -224,7 +224,7 @@ class Response implements ResponseInterface
     }
 
     /**
-     * DEPRECATED
+     * @deprecated
      * @param $statusCode
      */
     private function assertStatusCodeRange($statusCode)


### PR DESCRIPTION
There are a lot of incompatibility issues appeared because of the new psr/http-message package version.

Here is one for example:
`Fatal error: Declaration of Comet\Request::getServerParams() must be compatible with Psr\Http\Message\ServerRequestInterface::getServerParams(): array in /app/vendor/gotzmann/comet/src/Request.php on line 266`